### PR TITLE
Monkey-patch _msvccompile.gen_lib_option like any other compilators

### DIFF
--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -617,7 +617,7 @@ ccompiler.gen_lib_options = gen_lib_options
 # Also fix up the various compiler modules, which do
 # from distutils.ccompiler import gen_lib_options
 # Don't bother with mwerks, as we don't support Classic Mac.
-for _cc in ['msvc9', 'msvc', 'bcpp', 'cygwinc', 'emxc', 'unixc']:
+for _cc in ['msvc9', 'msvc', '_msvc', 'bcpp', 'cygwinc', 'emxc', 'unixc']:
     _m = sys.modules.get('distutils.' + _cc + 'compiler')
     if _m is not None:
         setattr(_m, 'gen_lib_options', gen_lib_options)


### PR DESCRIPTION
`setuptools` is now using `_msvccompile` instead of `msvccompile9`.

numpy is monkey-patching symmetrically `gen_lib_options` and `spawn` function for all compilators. But `_msvccompile.gen_lib_options` was not monkey-patched while `_msvccompile.spawn` is already monkey-patched throug the super class `ccompiler.spawn`.

This patch only symmetrically patch `_msvccompile` to prevent param file quoting.
